### PR TITLE
Fixing doraemon-wake script exiting with error everywhere.

### DIFF
--- a/doraemon.spec
+++ b/doraemon.spec
@@ -1,6 +1,6 @@
 Summary: Helps client to join domain and maintain itself
 Name: doraemon
-Version: 2.0.2
+Version: 2.0.3
 Release: 1.ns6
 URL: https://github.com/bglug-it/doraemon/
 License: GPLv2+
@@ -145,6 +145,10 @@ rm -rf %{buildroot}
 
 
 %changelog
+* Sun Jun 17 2018 Emiliano Vavassori <syntaxerrormmm-AT-gmail.com> - 2.0.3-1
+- FIX: whatsmyhostname correctly parse role variable
+- Minor aesthetic syntax fixes
+
 * Sun Oct 8 2017 Paolo Asperti <paolo@asperti.com> - 2.0.2-1
 - FIX: bug in WOL
 - FIX: small language typos

--- a/root/etc/e-smith/events/actions/doraemon-wake
+++ b/root/etc/e-smith/events/actions/doraemon-wake
@@ -26,7 +26,7 @@ sub wake_host
     # Wake up the host
     #------------------------------------------------------------
 
-    my $h = $db_hosts->get($hostName) or die "No host record for $hostName";
+    my @h = $db_hosts->get($hostName) or die "No host record for $hostName";
     my $client = $h[0];
     my $mac = $client->prop('MacAddress');
     system("/sbin/ether-wake -b -i lan0 $mac") == 0


### PR DESCRIPTION
This should fix a fatal error with `strict` within `doraemon-wake` and allow correct wakeups for client.